### PR TITLE
ui#748 - Card types - get from api, remove hardcoding

### DIFF
--- a/Client/Cards/index.ts
+++ b/Client/Cards/index.ts
@@ -254,4 +254,7 @@ export class Cards extends List<
 		)
 		return result
 	}
+	async getDisplayableCardTypesForProvider(provider: model.ProviderCode = "modulr") {
+		return await this.connection.get<Record<string, string>>(`v2/cards/types/displayable/${provider}`)
+	}
 }


### PR DESCRIPTION
already had the card type endpoint for `v2/cards/types/{providerCode}`