### PR TITLE
mpay-server#1019 - Approve pending card should create transaction showing approval, as well as card create entry on generate

### DIFF
--- a/model/TransactionType.ts
+++ b/model/TransactionType.ts
@@ -12,6 +12,8 @@ const transactionType = [
 	"APPROVAL_PENDING",
 	"EXPIRE",
 	"UNKNOWN",
+	"PENDING_APPROVE",
+	"PENDING_DECLINE",
 ] as const
 
 export type TransactionType = typeof transactionType[number]


### PR DESCRIPTION
need to add these values to the type in the client