### PR TITLE
Add functions to ErrorResponse namespace

### DIFF
--- a/model/ErrorResponse.ts
+++ b/model/ErrorResponse.ts
@@ -14,4 +14,18 @@ export namespace ErrorResponse {
 			(value.code != undefined || value.errors != undefined)
 		)
 	}
+	export const roleMissingCode = 9
+	export function isRoleMissing(error?: ErrorResponse): boolean {
+		return error?.code == roleMissingCode
+	}
+	export namespace TwoFa {
+		export const incorrectCode = 13
+		export function isIncorrect(error?: ErrorResponse): boolean {
+			return error?.code == incorrectCode
+		}
+		export const requiredCode = 14
+		export function isRequired(error?: ErrorResponse): boolean {
+			return error?.code == requiredCode
+		}
+	}
 }


### PR DESCRIPTION
These method are added to replace these in UI.
![image](https://github.com/pax2pay/client-js/assets/14332757/396d6552-7c53-4376-9153-6317b29c6c2a)

So instead we can call
```ts
ErrorResponse.isRoleMissing(error)
ErrorResponse.TwoFa.isIncorrect(error)
ErrorResponse.TwoFa.isRequired(error)
```
Was not 100% sure about the names especially `isRequiringTwofaSetupError` -> `isRequired` (maybe `isRequingSetup`?).