### PR TITLE
Bump isly version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.3.117",
 			"license": "MIT",
 			"dependencies": {
-				"isly": "^0.1.13",
+				"isly": "^0.1.20",
 				"isoly": "^0.1.16",
 				"isomorphic-fetch": "^3.0.0",
 				"math-exact": "^1.0.5"
@@ -4092,9 +4092,10 @@
 			"dev": true
 		},
 		"node_modules/isly": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/isly/-/isly-0.1.13.tgz",
-			"integrity": "sha512-bjyVNtONE5Dl2F6NywCEu50coVkGFc7L0YVOFG/EcYSBaT8VH0H2Ti7ybdaerpIviFixbRopkiDZqui8hWTK8Q=="
+			"version": "0.1.20",
+			"resolved": "https://registry.npmjs.org/isly/-/isly-0.1.20.tgz",
+			"integrity": "sha512-biYKDiE1LiIqpdOWfobqu8VaZ2Lwj9Hs9IFs7VaeVV8Hsd/WbUqyCdAO2imNUWOSfb2nSDKlIHa/z05USBX6bw==",
+			"license": "MIT"
 		},
 		"node_modules/isoly": {
 			"version": "0.1.28",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 	},
 	"dependencies": {
 		"isoly": "^0.1.16",
-		"isly": "^0.1.13",
+		"isly": "^0.1.20",
 		"isomorphic-fetch": "^3.0.0",
 		"math-exact": "^1.0.5"
 	},


### PR DESCRIPTION
The isly version was bumped in smoothly. And when we have two different versions on client and smoothly, things break for some weird reason.