### PR TITLE
UI#2287 - Approval notification config

### DIFF
--- a/Client/Accounts/index.ts
+++ b/Client/Accounts/index.ts
@@ -3,7 +3,7 @@ import { Connection } from "../Connection"
 import { List } from "../List"
 
 export class Accounts extends List<model.AccountResponse> {
-	protected folder = "funding-accounts"
+	protected readonly folder = "funding-accounts"
 	private constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Api-keys/index.ts
+++ b/Client/Api-keys/index.ts
@@ -2,7 +2,7 @@ import * as model from "../../model"
 import { Connection } from "../Connection"
 import { List } from "../List"
 export class ApiKeys extends List<model.ApiKeyResponse> {
-	protected folder = "api-keys"
+	protected readonly folder = "api-keys"
 	private constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Beneficiaries/index.ts
+++ b/Client/Beneficiaries/index.ts
@@ -3,7 +3,7 @@ import { Connection } from "../Connection"
 import { List } from "../List"
 
 export class Beneficiaries extends List<model.BeneficiaryResponse> {
-	protected folder = "beneficiaries"
+	protected readonly folder = "beneficiaries"
 	constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Categories/index.ts
+++ b/Client/Categories/index.ts
@@ -3,7 +3,7 @@ import { CategoryResponse } from "../../model/CategoryResponse"
 import { Connection } from "../Connection"
 import { List } from "../List"
 export class Categories extends List<model.CategoryResponse> {
-	protected folder = "category"
+	protected readonly folder = "category"
 	private constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Configuration/index.ts
+++ b/Client/Configuration/index.ts
@@ -3,7 +3,7 @@ import * as model from "../../model"
 import { ProviderCode } from "../../model/ProviderCode"
 import { Connection } from "../Connection"
 export class Configuration {
-	protected folder = "config"
+	protected readonly folder = "config"
 	constructor(private readonly connection: Connection) {}
 	static create(connection: Connection) {
 		return new Configuration(connection)
@@ -11,90 +11,42 @@ export class Configuration {
 	async getAvailableCurrency(providerCode: ProviderCode = "modulr"): Promise<Currency[] | model.ErrorResponse> {
 		return await this.connection.get<Currency[]>(`${this.folder}/currencies`, { provider: providerCode })
 	}
-	async getOrganisation(): Promise<model.OrganisationConfig | model.ErrorResponse> {
-		return await this.connection.get<model.OrganisationConfig>(`${this.folder}/organisation`)
+	async getOrganisation(code?: string): Promise<model.OrganisationConfig | model.ErrorResponse> {
+		return await this.connection.get<model.OrganisationConfig>(`${this.folder}/organisation${code ? `/${code}` : ""}`)
 	}
-	async updateOrganisation(request: model.OrganisationConfig): Promise<model.OrganisationConfig | model.ErrorResponse> {
-		return await this.connection.post<model.OrganisationConfig>(`${this.folder}/organisation`, request)
-	}
-	async getInternalOrganisation(organisation: string): Promise<model.InternalOrganisationConfig | model.ErrorResponse> {
-		return await this.connection.get<model.InternalOrganisationConfig>(
-			`${this.folder}/organisation_internal/${organisation}`
-		)
-	}
-	async updateInternalOrganisation(
-		organisation: string,
-		request: model.InternalOrganisationConfig
-	): Promise<model.InternalOrganisationConfig | model.ErrorResponse> {
-		return await this.connection.post<model.InternalOrganisationConfig>(
-			`${this.folder}/organisation_internal/${organisation}`,
+	async updateOrganisation(
+		request: model.OrganisationConfig,
+		code?: string
+	): Promise<model.OrganisationConfig | model.ErrorResponse> {
+		return await this.connection.post<model.OrganisationConfig>(
+			`${this.folder}/organisation${code ? `/${code}` : ""}`,
 			request
 		)
 	}
-	async getUser(): Promise<model.UserConfig | model.ErrorResponse> {
-		return await this.connection.get<model.UserConfig>(`${this.folder}/user`)
+	async getInternalOrganisation(code?: string): Promise<model.InternalOrganisationConfig | model.ErrorResponse> {
+		return await this.connection.get<model.InternalOrganisationConfig>(
+			`${this.folder}/organisation_internal/${code ? `/${code}` : ""}`
+		)
 	}
-	async updateUser(request: model.UserConfig): Promise<model.UserConfig | model.ErrorResponse> {
-		return await this.connection.post<model.UserConfig>(`${this.folder}/user`, request)
+	async updateInternalOrganisation(
+		request: model.InternalOrganisationConfig,
+		code?: string
+	): Promise<model.InternalOrganisationConfig | model.ErrorResponse> {
+		return await this.connection.post<model.InternalOrganisationConfig>(
+			`${this.folder}/organisation_internal/${code ? `/${code}` : ""}`,
+			request
+		)
+	}
+	async getUser(username?: string): Promise<model.UserConfig | model.ErrorResponse> {
+		return await this.connection.get<model.UserConfig>(`${this.folder}/user${username ? `/${username}` : ""}`)
+	}
+	async updateUser(request: model.UserConfig, username?: string): Promise<model.UserConfig | model.ErrorResponse> {
+		return await this.connection.post<model.UserConfig>(`${this.folder}/user${username ? `/${username}` : ""}`, request)
 	}
 	async getPortalFeatures(): Promise<model.PaxpayFeature[] | model.ErrorResponse> {
 		return await this.connection.get<model.PaxpayFeature[]>(`${this.folder}/portal`)
 	}
 	async getConfigValueFromKey(category: string, key: string): Promise<any | model.ErrorResponse> {
 		return await this.connection.get<any>(`${this.folder}/key/${category}/${key}`)
-	}
-
-	async setupCredentials(
-		organisationCode: string,
-		providerCode: ProviderCode,
-		request: model.CredentialRequest
-	): Promise<model.CredentialResponse | model.ErrorResponse> {
-		const header = { "x-assume": organisationCode }
-		return await this.connection.post<model.CredentialResponse>(
-			`credentials/${providerCode}/setup`,
-			request,
-			undefined,
-			header
-		)
-	}
-	async getAllCredentials(organisationCode: string): Promise<model.CredentialResponse[] | model.ErrorResponse> {
-		const header = { "x-assume": organisationCode }
-		const parameters = { totalCount: false }
-		const response = await this.connection.get<{ list: model.CredentialResponse[]; totalCount: number }>(
-			`credentials`,
-			parameters,
-			header
-		)
-		if (model.ErrorResponse.is(response))
-			return response
-		else
-			return response.list
-	}
-
-	async updateCredentials(
-		organisationCode: string,
-		providerCode: ProviderCode,
-		request: model.CredentialRequest
-	): Promise<model.CredentialResponse | model.ErrorResponse> {
-		const header = { "x-assume": organisationCode }
-		return await this.connection.put<model.CredentialResponse>(
-			`credentials/${providerCode}`,
-			request,
-			undefined,
-			header
-		)
-	}
-	async saveCredentials(
-		organisationCode: string,
-		providerCode: ProviderCode,
-		request: model.CredentialRequest
-	): Promise<model.CredentialResponse | model.ErrorResponse> {
-		const header = { "x-assume": organisationCode }
-		return await this.connection.post<model.CredentialResponse>(
-			`credentials/${providerCode}`,
-			request,
-			undefined,
-			header
-		)
 	}
 }

--- a/Client/Credentials/index.ts
+++ b/Client/Credentials/index.ts
@@ -1,0 +1,63 @@
+import * as model from "../../model"
+import { ProviderCode } from "../../model/ProviderCode"
+import { Connection } from "../Connection"
+export class Credentials {
+	protected readonly folder = "credentials"
+	constructor(private readonly connection: Connection) {}
+	static create(connection: Connection) {
+		return new Credentials(connection)
+	}
+	async setup(
+		organisationCode: string,
+		providerCode: ProviderCode,
+		request: model.CredentialRequest
+	): Promise<model.CredentialResponse | model.ErrorResponse> {
+		const header = { "x-assume": organisationCode }
+		return await this.connection.post<model.CredentialResponse>(
+			`${this.folder}/${providerCode}/setup`,
+			request,
+			undefined,
+			header
+		)
+	}
+	async getAll(organisationCode: string): Promise<model.CredentialResponse[] | model.ErrorResponse> {
+		const header = { "x-assume": organisationCode }
+		const parameters = { totalCount: false }
+		const response = await this.connection.get<{ list: model.CredentialResponse[]; totalCount: number }>(
+			`${this.folder}`,
+			parameters,
+			header
+		)
+		if (model.ErrorResponse.is(response))
+			return response
+		else
+			return response.list
+	}
+
+	async update(
+		organisationCode: string,
+		providerCode: ProviderCode,
+		request: model.CredentialRequest
+	): Promise<model.CredentialResponse | model.ErrorResponse> {
+		const header = { "x-assume": organisationCode }
+		return await this.connection.put<model.CredentialResponse>(
+			`${this.folder}/${providerCode}`,
+			request,
+			undefined,
+			header
+		)
+	}
+	async save(
+		organisationCode: string,
+		providerCode: ProviderCode,
+		request: model.CredentialRequest
+	): Promise<model.CredentialResponse | model.ErrorResponse> {
+		const header = { "x-assume": organisationCode }
+		return await this.connection.post<model.CredentialResponse>(
+			`${this.folder}/${providerCode}`,
+			request,
+			undefined,
+			header
+		)
+	}
+}

--- a/Client/Currency/index.ts
+++ b/Client/Currency/index.ts
@@ -5,7 +5,7 @@ import { CurrencyConversionResponse } from "../../model/CurrencyConversionRespon
 import { Connection } from "../Connection"
 
 export class Currency {
-	protected folder = "currency"
+	protected readonly folder = "currency"
 	#connection: Connection
 	protected get connection() {
 		return this.#connection

--- a/Client/Email/index.ts
+++ b/Client/Email/index.ts
@@ -2,7 +2,7 @@ import * as model from "../../model"
 import { Connection } from "../Connection"
 
 export class Email {
-	protected folder = "email"
+	protected readonly folder = "email"
 	constructor(private readonly connection: Connection) {}
 	static create(connection: Connection) {
 		return new Email(connection)

--- a/Client/Merchants/index.ts
+++ b/Client/Merchants/index.ts
@@ -4,7 +4,7 @@ import { List } from "../List"
 import { Paginated } from "../Paginated"
 
 export class Merchants extends List<model.MerchantResponse> {
-	protected folder = "merchants" as const
+	protected readonly folder = "merchants"
 	constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Metadata/index.ts
+++ b/Client/Metadata/index.ts
@@ -4,7 +4,7 @@ import { List } from "../List"
 import { Paginated } from "../Paginated"
 
 export class Metadata extends List<MetadataFormat.Response> {
-	protected folder = "metadata" as const
+	protected readonly folder = "metadata"
 	constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Organisations/index.ts
+++ b/Client/Organisations/index.ts
@@ -3,7 +3,7 @@ import { Connection } from "../Connection"
 import { List } from "../List"
 
 export class Organisations extends List<model.OrganisationResponse> {
-	protected readonly folder = "organisations" as const
+	protected readonly folder = "organisations"
 	constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Rolesets/index.ts
+++ b/Client/Rolesets/index.ts
@@ -2,7 +2,7 @@ import * as model from "../../model"
 import { Connection } from "../Connection"
 import { List } from "../List"
 export class Rolesets extends List<model.RolesetResponse> {
-	protected folder = "rolesets"
+	protected readonly folder = "rolesets"
 	private constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Transfers/index.ts
+++ b/Client/Transfers/index.ts
@@ -5,7 +5,7 @@ import { List } from "../List"
 import { Paginated } from "../Paginated"
 
 export class Transfers extends List<model.TransferResponse> {
-	protected folder = "transfers"
+	protected readonly folder = "transfers"
 	constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/Users/index.ts
+++ b/Client/Users/index.ts
@@ -4,7 +4,7 @@ import { List } from "../List"
 import { Paginated } from "../Paginated"
 
 export class Users extends List<model.UserResponse> {
-	protected folder = "users"
+	protected readonly folder = "users"
 	private constructor(connection: Connection) {
 		super(connection)
 	}

--- a/Client/index.ts
+++ b/Client/index.ts
@@ -6,6 +6,7 @@ import { Cards as ClientCards } from "./Cards"
 import { Categories as ClientCategories } from "./Categories"
 import { Configuration as ClientConfiguration } from "./Configuration"
 import { Connection } from "./Connection"
+import { Credentials as ClientCredentials } from "./Credentials"
 import { Currency as ClientCurrency } from "./Currency"
 import { Email as ClientEmail } from "./Email"
 import { List as ClientList } from "./List"
@@ -32,6 +33,7 @@ export class Client {
 	cards = ClientCards.create(this.connection)
 	categories = ClientCategories.create(this.connection)
 	configuration = ClientConfiguration.create(this.connection)
+	credentials = ClientCredentials.create(this.connection)
 	currency = ClientCurrency.create(this.connection)
 	email = ClientEmail.create(this.connection)
 	merchants = ClientMerchants.create(this.connection)
@@ -66,6 +68,7 @@ export namespace Client {
 	export type Cards = ClientCards
 	export type Categories = ClientCategories
 	export type Configuration = ClientConfiguration
+	export type Credentials = ClientCredentials
 	export type Currency = ClientCurrency
 	export type Email = ClientEmail
 	export type Merchants = ClientMerchants

--- a/model/ApprovalNotificationConfig.ts
+++ b/model/ApprovalNotificationConfig.ts
@@ -1,0 +1,15 @@
+import { isly } from "isly"
+
+export interface ApprovalNotificationConfig {
+	enabled: boolean
+	sendToAllValidApprovers?: boolean
+	additionalEmails?: string[]
+}
+
+export namespace ApprovalNotificationConfig {
+	export const type = isly.object<ApprovalNotificationConfig>({
+		enabled: isly.boolean(),
+		sendToAllValidApprovers: isly.boolean().optional(),
+		additionalEmails: isly.string().array().optional(),
+	})
+}

--- a/model/CardDeliveryEmailConfig.ts
+++ b/model/CardDeliveryEmailConfig.ts
@@ -1,14 +1,15 @@
+import { isly } from "isly"
+
 export interface CardDeliveryEmailConfig {
 	contactEmail?: string
 	useContactEmailAsReplyTo?: boolean
 	contactPhoneNumber?: string
 }
 export namespace CardDeliveryEmailConfig {
-	export function is(value: CardDeliveryEmailConfig | any): value is CardDeliveryEmailConfig {
-		return (
-			(typeof value.contactEmail == "string" || value.contactEmail == undefined) &&
-			(typeof value.useContactEmailAsReplyTo == "string" || value.useContactEmailAsReplyTo == undefined) &&
-			(typeof value.contactPhoneNumber == "string" || value.contactPhoneNumber == undefined)
-		)
-	}
+	export const type = isly.object<CardDeliveryEmailConfig>({
+		contactEmail: isly.string().optional(),
+		useContactEmailAsReplyTo: isly.boolean().optional(),
+		contactPhoneNumber: isly.string().optional(),
+	})
+	export const is = type.is
 }

--- a/model/CardTypesConfig.ts
+++ b/model/CardTypesConfig.ts
@@ -1,3 +1,4 @@
+import { isly } from "isly"
 import { ProviderCode } from "./ProviderCode"
 /**
  * Config related to card types
@@ -7,4 +8,13 @@ export interface CardTypesConfig {
 	hideCardTypes?: any
 	onlyShowCardTypes?: any
 	aliases?: Partial<Record<ProviderCode, Record<string, string>>>
+}
+
+export namespace CardTypesConfig {
+	export const type = isly.object<CardTypesConfig>({
+		useLegacyCardTypesInResponse: isly.boolean().optional(),
+		hideCardTypes: isly.any().optional(),
+		onlyShowCardTypes: isly.any().optional(),
+		aliases: isly.record(ProviderCode.type, isly.record(isly.string(), isly.string())).optional(),
+	})
 }

--- a/model/CardUsage.ts
+++ b/model/CardUsage.ts
@@ -1,7 +1,9 @@
-export type CardUsage = "SINGLE_USE" | "MULTIPLE_USE" | "SINGLE_USE_ALLOW_TEST_AUTH"
+import { isly } from "isly"
+
+export type CardUsage = typeof CardUsage.values[number]
 
 export namespace CardUsage {
-	export function is(value: CardUsage | any): value is CardUsage {
-		return value == "SINGLE_USE" || value == "MULTIPLE_USE" || value == "SINGLE_USE_ALLOW_TEST_AUTH"
-	}
+	export const values = ["SINGLE_USE", "MULTIPLE_USE", "SINGLE_USE_ALLOW_TEST_AUTH"] as const
+	export const type = isly.string(values)
+	export const is = type.is
 }

--- a/model/CreateCardRequest.ts
+++ b/model/CreateCardRequest.ts
@@ -3,6 +3,7 @@ import { CardAmendmentScheduledTaskRequest } from "./CardAmendmentScheduledTaskR
 import { CardDeliveryRequest } from "./CardDeliveryRequest"
 import { CardStateChangeScheduledTaskRequest } from "./CardStateChangeScheduledTaskRequest"
 import { CardTypeSpecification } from "./CardTypeSpecification"
+import { CardUsage } from "./CardUsage"
 import { ProviderCode } from "./ProviderCode"
 import { ScheduledTaskRequest } from "./ScheduledTaskRequest"
 
@@ -18,7 +19,7 @@ export interface CreateCardRequest {
 	currency: string
 	fundingDate?: string
 	expiryDate?: any
-	usage?: "SINGLE_USE" | "MULTIPLE_USE" | "SINGLE_USE_ALLOW_TEST_AUTH"
+	usage?: CardUsage
 	schedule?: (CardAmendmentScheduledTaskRequest | CardStateChangeScheduledTaskRequest | ScheduledTaskRequest)[]
 	friendlyName?: string
 	delivery?: CardDeliveryRequest

--- a/model/FundingAccountInboundTransferNotificationConfig.ts
+++ b/model/FundingAccountInboundTransferNotificationConfig.ts
@@ -1,7 +1,16 @@
+import { isly } from "isly"
+
 /**
  * Config related to notifications for deposits made into funding accounts
  */
 export interface FundingAccountInboundTransferNotificationConfig {
 	enabled?: boolean
 	emails?: string[]
+}
+export namespace FundingAccountInboundTransferNotificationConfig {
+	export const type = isly.object<FundingAccountInboundTransferNotificationConfig>({
+		enabled: isly.boolean().optional(),
+		emails: isly.string().array().optional(),
+	})
+	export const is = type.is
 }

--- a/model/FundingLimitConfig.ts
+++ b/model/FundingLimitConfig.ts
@@ -1,9 +1,13 @@
+import { isly } from "isly"
+
 export interface FundingLimitConfig {
 	type: "ON_THRESHOLD" | "TIMED_ONLY" | "ON_THRESHOLD_AND_TIMED"
 	limits?: any
 }
 export namespace FundingLimitConfig {
-	export function is(value: FundingLimitConfig | any): value is FundingLimitConfig {
-		return value.type == "ON_THRESHOLD" || value.type == "TIME_ONLY" || value.type == "ON_THRESHOLD_AND_TIMED"
-	}
+	export const type = isly.object<FundingLimitConfig>({
+		type: isly.string(["ON_THRESHOLD", "TIMED_ONLY", "ON_THRESHOLD_AND_TIMED"]),
+		limits: isly.any().optional(),
+	})
+	export const is = type.is
 }

--- a/model/OrganisationConfig.ts
+++ b/model/OrganisationConfig.ts
@@ -1,4 +1,6 @@
 import { Currency } from "isoly"
+import { isly } from "isly"
+import { ApprovalNotificationConfig } from "./ApprovalNotificationConfig"
 import { CardDeliveryEmailConfig } from "./CardDeliveryEmailConfig"
 import { CardTypesConfig } from "./CardTypesConfig"
 import { CardUsage } from "./CardUsage"
@@ -11,13 +13,14 @@ import { SecurityConfig } from "./SecurityConfig"
  */
 export interface OrganisationConfig {
 	showDefaultRolesets?: boolean
-	defaultModulrUsage?: "SINGLE_USE" | "SINGLE_USE_ALLOW_TEST_AUTH" | "MULTIPLE_USE"
+	defaultModulrUsage?: CardUsage
 	defaultExpiryMonthDelta?: number
 	defaultExpiryMonthDeltaPerCurrency?: Partial<Record<Currency, number>>
 	defaultPortalCardType?: Partial<Record<ProviderCode, string>>
 	defaultPortalFundingAccount?: Partial<Record<ProviderCode, string>>
 	cardTypes?: CardTypesConfig
 	inboundTransferConfig?: FundingAccountInboundTransferNotificationConfig
+	approvalNotificationConfig?: ApprovalNotificationConfig
 	fundingLimitConfig?: FundingLimitConfig
 	cardDeliveryEmailConfig?: CardDeliveryEmailConfig
 	portalHideMultipleUseOption?: boolean
@@ -25,10 +28,21 @@ export interface OrganisationConfig {
 }
 
 export namespace OrganisationConfig {
-	export function is(value: OrganisationConfig | any): value is OrganisationConfig {
-		return (
-			value == undefined ||
-			(typeof value == "object" && (value.defaultModulrUsage == undefined || CardUsage.is(value.defaultModulrUsage)))
-		)
-	}
+	const currencyType = isly.fromIs<Currency>("Currency", Currency.is)
+	export const type = isly.object<OrganisationConfig>({
+		showDefaultRolesets: isly.boolean().optional(),
+		defaultModulrUsage: CardUsage.type.optional(),
+		defaultExpiryMonthDelta: isly.number().optional(),
+		defaultExpiryMonthDeltaPerCurrency: isly.record(currencyType, isly.number()).optional(),
+		defaultPortalCardType: isly.record(ProviderCode.type, isly.string()).optional(),
+		defaultPortalFundingAccount: isly.record(ProviderCode.type, isly.string()).optional(),
+		cardTypes: CardTypesConfig.type.optional(),
+		inboundTransferConfig: FundingAccountInboundTransferNotificationConfig.type.optional(),
+		approvalNotificationConfig: ApprovalNotificationConfig.type.optional(),
+		fundingLimitConfig: FundingLimitConfig.type.optional(),
+		cardDeliveryEmailConfig: CardDeliveryEmailConfig.type.optional(),
+		portalHideMultipleUseOption: isly.boolean().optional(),
+		securityConfig: SecurityConfig.type.optional(),
+	})
+	export const is = type.is
 }


### PR DESCRIPTION
## Also clean up
- Add `isly` type to `OrganisationConfig`
- Make `/config/{type}` | `/config/{type}/{value}` methods consistent in Configuration client.
- Split `/credentials` calls to own `Credentials` client, they where previously in `Configuration` client. 
- Make `client.folder` consistently `readonly` 