### PR TITLE
ui#3223 - Fix CardTypes.getAvailable method for no availabilityType

### DIFF
--- a/Client/CardTypes/index.ts
+++ b/Client/CardTypes/index.ts
@@ -39,7 +39,7 @@ export class CardTypes extends List<model.CardTypeResponse> {
 	) {
 		const header = organisationCode ? { "x-assume": organisationCode } : undefined
 		return await this.connection.get<model.AvailableCardTypesResponse>(
-			`v2/${this.folder}/available/${availabilityType}${name ? `/${name}` : ""}`,
+			`v2/${this.folder}/available/${availabilityType ?? ""}${availabilityType && name ? `/${name}` : ""}`,
 			undefined,
 			header
 		)


### PR DESCRIPTION
Would send `/available/undefined` if you left out availabilityType before.