### PR TITLE
revert credentials: include

### DIFF
--- a/Client/Connection.ts
+++ b/Client/Connection.ts
@@ -42,7 +42,7 @@ export class Connection {
 		const body = this.prepareBody(request)
 
 		try {
-			const response = await fetch(url, { method, headers, body, credentials: "include" })
+			const response = await fetch(url, { method, headers, body })
 
 			// Handle Side Effects (Cookies/2FA)
 			this.handleSessionSideEffects(response)


### PR DESCRIPTION

<img width="1143" height="163" alt="Screenshot from 2026-05-04 15-34-59" src="https://github.com/user-attachments/assets/3e2ca790-39cf-4a61-9ade-3d7842d47987" />
cannot use credentials with a wildcard origin (*)