### PR TITLE
Add payment field to StatementReportResponseRow

### DIFF
--- a/model/StatementReportResponseRow.spec.ts
+++ b/model/StatementReportResponseRow.spec.ts
@@ -91,6 +91,87 @@ describe("StatementReportResponseRow is", () => {
 		expect(StatementReportResponseRow.is(json)).toBeTruthy()
 	})
 
+	it("card row full with payment", async () => {
+		const json = {
+			actionType: "AUTHORISATION",
+			amount: {
+				billing: {
+					amount: -1,
+					currency: "GBP",
+				},
+				transaction: {
+					amount: -1,
+					currency: "GBP",
+				},
+				fxRate: 1,
+			},
+			postedDate: "2022-10-11T10:29:15.398511",
+			transactionDate: "2022-10-11T10:29:15.398511",
+			actualBalance: -1,
+			availableBalance: -1,
+			rowType: "full",
+			ids: {
+				rowId: "R000000000000424",
+				providerCode: "modulr",
+				providerCardId: "V21001M33H",
+			},
+			payment: {
+				id: "Y0000036I",
+				batchId: "BAT0000001",
+				account: "A0000SJ",
+				amount: 1,
+				remaining: 1,
+				total: 1,
+				currency: "GBP",
+				state: "active",
+				method: "card",
+				createdBy: "lucym",
+				createdOn: "2022-10-11T10:29:15.398511",
+			},
+		}
+		expect(StatementReportResponseRow.is(json)).toBeTruthy()
+	})
+
+	it("card row summary with payment", async () => {
+		const json = {
+			actionType: "AUTHORISATION",
+			amount: {
+				billing: {
+					amount: -1,
+					currency: "GBP",
+				},
+				transaction: {
+					amount: -1,
+					currency: "GBP",
+				},
+				fxRate: 1,
+			},
+			postedDate: "2022-10-11T10:29:15.398511",
+			actualBalance: -1,
+			availableBalance: -1,
+			rowType: "summary",
+			ids: {
+				rowId: "R000000000000424",
+				providerCode: "modulr",
+				providerCardId: "V21001M33H",
+			},
+			payment: {
+				id: "Y0000036I",
+				batchId: "BAT0000001",
+				account: "A0000SJ",
+				amount: 1,
+				remaining: 1,
+				total: 1,
+				currency: "GBP",
+				state: "active",
+				method: "card",
+				createdBy: "lucym",
+				createdOn: "2022-10-11T10:29:15.398511",
+			},
+		}
+		expect(StatementReportResponseRow.is(json)).toBeTruthy()
+	})
+
 	it("should be false", async () => {
 		expect(StatementReportResponseRow.is(noAmount)).toBeFalsy()
 

--- a/model/StatementReportResponseRow.spec.ts
+++ b/model/StatementReportResponseRow.spec.ts
@@ -165,6 +165,13 @@ describe("StatementReportResponseRow is", () => {
 				currency: "GBP",
 				state: "active",
 				method: "card",
+				card: {
+					id: "C0000001",
+					providerCode: "modulr",
+					providerCardId: "V21001M33H",
+					cardType: "virtual",
+					pan: "1234",
+				},
 				createdBy: "lucym",
 				createdOn: "2022-10-11T10:29:15.398511",
 			},

--- a/model/StatementReportResponseRow.ts
+++ b/model/StatementReportResponseRow.ts
@@ -5,10 +5,12 @@ import { CardResponseV2Summary } from "./CardResponseV2Summary"
 import { CardScheduleResponseItem } from "./CardScheduleResponseItem"
 import { FutureTransactionPrognosisAmountPair } from "./FutureTransactionPrognosisAmountPair"
 import { MetadataResponse } from "./MetadataResponse"
+import { PaymentResponse } from "./PaymentResponse"
 import { StatementReportRowActionType } from "./StatementReportRowActionType"
 import { StatementReportRowType } from "./StatementReportRowType"
 import { StatementRowIds } from "./StatementRowIds"
 import { StatementTransferSpecificType } from "./StatementTransferSpecificType"
+import { SummaryPaymentResponse } from "./SummaryPaymentResponse"
 import { TransferResponseV2 } from "./TransferResponseV2"
 import { TransferResponseV2Summary } from "./TransferResponseV2Summary"
 
@@ -24,9 +26,11 @@ export interface StatementReportResponseRow {
 	rowType: StatementReportRowType
 	transferType?: StatementTransferSpecificType
 	ids: StatementRowIds
+	/** @deprecated Use payment.card instead. Will be removed in a future release. */
 	card?: CardResponseV2 | CardResponseV2Summary
 	scheduledTask?: CardScheduleResponseItem
 	transfer?: TransferResponseV2 | TransferResponseV2Summary
+	payment?: PaymentResponse | SummaryPaymentResponse
 }
 
 export namespace StatementReportResponseRow {
@@ -47,7 +51,8 @@ export namespace StatementReportResponseRow {
 			(value.card == undefined || CardResponseV2.is(value.card) || CardResponseV2Summary.is(value.card)) &&
 			(value.transfer == undefined ||
 				TransferResponseV2.is(value.transfer) ||
-				TransferResponseV2Summary.is(value.transfer))
+				TransferResponseV2Summary.is(value.transfer)) &&
+			(value.payment == undefined || PaymentResponse.is(value.payment) || SummaryPaymentResponse.is(value.payment))
 		)
 	}
 }

--- a/model/SummaryPaymentResponse.ts
+++ b/model/SummaryPaymentResponse.ts
@@ -8,3 +8,11 @@ export interface SummaryPaymentResponse extends AbstractPaymentResponse {
 	card?: SummaryCardResponseV3
 	transfer?: TransferResponseV3
 }
+export namespace SummaryPaymentResponse {
+	export const type = AbstractPaymentResponse.type.extend<SummaryPaymentResponse>({
+		merchant: SummaryMerchantResponse.type.optional(),
+		card: SummaryCardResponseV3.type.optional(),
+		transfer: TransferResponseV3.type.optional(),
+	})
+	export const is = type.is
+}


### PR DESCRIPTION
## Summary
- `StatementReportResponseRow.card` was deprecated server-side in favor of `payment.card` (mpay-server #3916 / pax2pay/ui#4003), which also populates `payment.batchId` for statement rows.
- This client hadn't caught up: `StatementReportResponseRow` had no `payment` field at all.
- Adds `payment?: PaymentResponse | SummaryPaymentResponse`, mirroring the existing `card`/`transfer` full-summary pattern, and adds a missing `is()`/`type` validator to `SummaryPaymentResponse` (it previously had none).

## Needed for
pax2pay/ui#4055 ("Display batch ids in statements") — the ui repo's statement row will migrate off `card` onto `payment` once this is published.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run test` (25 suites, 73 tests, all passing)

Note: merging this triggers an automatic version bump + npm publish (bump.yml/publish.yml). Please review before merging since this is a shared library.